### PR TITLE
Prepare netplan

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,12 @@ Linux distributions.
 ## Parameters
 
 ```
-Usage: bms-network-setup.py [-d] [-s|u|r]
+Usage: bms-network-setup.py [-d] [-s|u|r|n]
  -d: Debug: reads network_data.json and writes ifcfg-* in current dir
  -s: SuSE: assume we run on a SuSE distribution
  -u: Debian: assume we run on a Debian/Ubuntu distribution
  -r: RedHat: assume we run on a RedHat/CentOS distribution
+ -n: Netplan: assume we run on a distribution using netplan
 ```
 By default, the script produces ifcfg files for the distribution it detects
 it's currently running on.

--- a/README.md
+++ b/README.md
@@ -2,13 +2,14 @@
 Script to parse network_data.json and configure ifcfg-* files from it.
 
 ## How it works
-This is a much more limited and much simpler script to enable networking on OTC Bare Metal instances.
+This is a  limited and simple script to enable networking on OTC Bare Metal instances.
 Bare Metal instances have a ConfigDrive that contains meta_data.json and network_data.json.
-The meta_data.json is unfortunately not fully correct at this point (wrong hostname) and user_data is missing,
+The meta_data.json is unfortunately not fully correct at this point (wrong hostname),
 so we prefer to use the network OpenStack DataSource via the normal cloud-init mechanism.
 However, to even get networking working, we need to parse and evaluate network_data.json.
 This scripts does this by parsing it and then writing out the network ifcfg-* files and then leaves
-it to the standard distribution networking mechanisms (wicked, ifup, NetworkManager, ...) to do the network setup.
+it to the standard distribution networking mechanisms (wicked, ifup, NetworkManager, ...) to do the network setup
+and leave it to cloud-init for all other cloud-init steps.
 
 In our package (on OpenBuildService 
 in [home:garloff:OTC](https://build.opensuse.org/package/show/home:garloff:OTC/bms-network-setup)), 

--- a/bms-network-setup.py
+++ b/bms-network-setup.py
@@ -289,8 +289,8 @@ SFMT = "%s=%s\n"
 if IS_NETPLAN:
 	IFCFG_PHY  = IFCFG_PHY_NETPLAN
 	IFCFG_BOND = IFCFG_BOND_NETPLAN
-	IFCFG_STAT = IFCFG_STATIC_DEBIAN
-	IFCFG_VLAN = IFCFG_VLAN_DEBIAN
+	IFCFG_STAT = ""
+	IFCFG_VLAN = ""
         SFMT = "      %s: %s\n"
 elif IS_DEB:
 	IFCFG_PHY  = IFCFG_PHY_DEBIAN
@@ -705,6 +705,13 @@ def process_network_hw():
 		f = open("%s/%sifcfg-%s%s" % (NETCONFPATH, PRE, nm, POST), "w")
 		six.print_(process_template(IFCFG_TMPL, ljson, njson, sjson, True), file=f)
 
+def apply_network_config():
+        if IS_NETPLAN:
+                os.system("netplan apply")
+        elif IS_DEB:
+                os.system("systemctl restart networking")
+
 # Entry point
 if __name__ == "__main__":
-	process_network_hw()
+        process_network_hw()
+        apply_network_config()

--- a/bms-network-setup.py
+++ b/bms-network-setup.py
@@ -6,6 +6,8 @@
 #
 # (c) Kurt Garloff <kurt@garloff.de>, 12/2017
 # License: CC-BY-SA 3.0
+#¤
+# add NETPLAN configuration, 07/2018 (sabrina-mueller@t-systems.com)
 
 import os
 import sys
@@ -707,9 +709,7 @@ def process_network_hw():
 
 def apply_network_config():
         if IS_NETPLAN:
-                os.system("netplan apply")
-        elif IS_DEB:
-                os.system("systemctl restart networking")
+                os.system("systemctl add-wants systemd-networkd-wait-online.service bms-network-setup")
 
 # Entry point
 if __name__ == "__main__":

--- a/bms-network-setup.py
+++ b/bms-network-setup.py
@@ -6,7 +6,7 @@
 #
 # (c) Kurt Garloff <kurt@garloff.de>, 12/2017
 # License: CC-BY-SA 3.0
-#¤
+#
 # add NETPLAN configuration, 07/2018 (sabrina-mueller@t-systems.com)
 
 import os
@@ -19,7 +19,7 @@ import subprocess
 
 
 def usage():
-	six.print_("Usage: bms-network-setup.py [-d] [-s|u|r]", file=sys.stderr)
+	six.print_("Usage: bms-network-setup.py [-d] [-s|u|r|n]", file=sys.stderr)
 	six.print_(" -d: Debug: reads network_data.json and writes ifcfg-* in current dir", file=sys.stderr)
 	six.print_(" -s: SuSE: assume we run on a SuSE distribution", file=sys.stderr)
 	six.print_(" -u: Debian: assume we run on a Debian/Ubuntu distribution", file=sys.stderr)

--- a/bms-network-setup.py
+++ b/bms-network-setup.py
@@ -35,11 +35,11 @@ for arg in sys.argv[1:]:
 	if arg == "-d":
 		DEBUG = True
 	elif arg == "-s":
-		IS_SUSE = True; IS_DEB = False; IS_EULER = False
+		IS_SUSE = True; IS_DEB = False; IS_EULER = False; IS_NETPLAN = False;
 	elif arg == "-u":
-		IS_DEB = True; IS_SUSE = False; IS_EULER = False
+		IS_DEB = True; IS_SUSE = False; IS_EULER = False; IS_NETPLAN = False;
 	elif arg == "-r":
-		IS_DEB = False; IS_SUSE = False; IS_EULER = False
+		IS_DEB = False; IS_SUSE = False; IS_EULER = False; IS_NETPLAN = False;
 	else:
 		six.print_("UNKNOWN ARG %s" % arg, file=sys.stderr)
 		usage()

--- a/bms-network-setup.py
+++ b/bms-network-setup.py
@@ -28,6 +28,7 @@ def usage():
 IS_SUSE  = os.path.exists("/etc/SuSE-release")
 IS_EULER = os.path.exists("/etc/euleros-release")
 IS_DEB   = os.path.exists("/etc/debian_version")
+IS_NETPLAN = os.path.exists("/etc/netplan")
 DEBUG = 0
 # Arg parsing
 for arg in sys.argv[1:]:
@@ -49,7 +50,9 @@ CONFDIR="."
 if not DEBUG:
 	WICKEDCONFPATH = "/etc/wicked/ifconfig/"
 	CONFDIR = "/etc"
-	if IS_DEB:
+	if IS_NETPLAN:
+		NETCONFPATH = "/etc/netplan/"
+	elif IS_DEB:
 		NETCONFPATH = "/etc/network/interfaces.d/"
 	elif IS_SUSE:
 		NETCONFPATH = "/etc/sysconfig/network/"
@@ -631,16 +634,19 @@ def process_network_hw():
 		if tp == "phy":
 			IFCFG_TMPL = IFCFG_PHY
 			PRE = "60-" if IS_DEB else ""
+                        POST = ".yaml" if IS_NETPLAN else ""
 		elif tp == "bond":
 			IFCFG_TMPL = IFCFG_BOND
 			PRE = "61-" if IS_DEB else ""
+                        POST = ".yaml" if IS_NETPLAN else ""
 		elif tp == "vlan":
 			IFCFG_TMPL = IFCFG_VLAN
 			PRE = "62-" if IS_DEB else ""
+                        POST = ".yaml" if IS_NETPLAN else ""
 		else:
 			six.print_("Unknown network type %s" % tp, file=sys.stderr)
 
-		f = open("%s/%sifcfg-%s" % (NETCONFPATH, PRE, nm), "w")
+		f = open("%s/%sifcfg-%s%s" % (NETCONFPATH, PRE, nm, POST), "w")
 		six.print_(process_template(IFCFG_TMPL, ljson, njson, sjson, True), file=f)
 
 # Entry point


### PR DESCRIPTION
Added NETPLAN as generell network configuration in parallel to IS_DEB, IS_SUSE, ... .

- Detect NETPLAN by existing of directory /etc/netplan.
- Use  network_data.json data to detect network configuration for 
   - physical interfaces
   - bond0 interface
- Write NETPLAN configuration files into /etc/netplan/  in yaml format.
- Add a new systemd service dependency: wanted-by: systemd-networkd-wait-online.service
  May this could also be done by building package itself.

NETPLAN configuration tested on Ubuntu-18.04 on OTC BMS instances.