### PR TITLE
Remove GATEWAY option for static VLAN interfaces for REDHAT family distributions.

### DIFF
--- a/bms-network-setup.py
+++ b/bms-network-setup.py
@@ -247,7 +247,6 @@ IFCFG_STATIC_REDHAT = (
 	('BOOTPROTO', 'none', HARD),	# static?
 	('IPADDR', 'ip_address', MAND),	# ADDRESS?
 	('NETMASK', 'netmask', MAND),
-	('GATEWAY', 'gateway', OPT),
 	('DNSx', '', NAMESERVERS),
 )
 


### PR DESCRIPTION
Additional VLAN interfaces can be configured by DHCP or with static ip-address.
VLAN interfaces configured by DHCP already does not set GATEWAY option.
VLAN interfaces  configured with static ip-address needs to avoid GATEWAY option as well.