### PR TITLE
Fix configuration for VLAN interfaces with static ip-address, to bring them UP after boot automatically.

### DIFF
--- a/bms-network-setup.py
+++ b/bms-network-setup.py
@@ -247,6 +247,7 @@ IFCFG_STATIC_REDHAT = (
 	('BOOTPROTO', 'none', HARD),	# static?
 	('IPADDR', 'ip_address', MAND),	# ADDRESS?
 	('NETMASK', 'netmask', MAND),
+	('GATEWAY', 'gateway', OPT),
 	('DNSx', '', NAMESERVERS),
 )
 

--- a/bms-network-setup.py
+++ b/bms-network-setup.py
@@ -510,7 +510,10 @@ def process_template(template, ljson, njson, sjson, note = True):
 		elif mode == OPT or mode == MAND:
 			try:
 				jval = ljson[val]
-				out += SFMT % (key, jval)
+				if jval == None:                                
+					pass
+				else:
+					out += SFMT % (key, jval)
 			except:
 				if mode == MAND:
 					LOG.error("Mandatory value %s not found for %s setting" % (val, key))

--- a/bms-network-setup.py
+++ b/bms-network-setup.py
@@ -247,7 +247,6 @@ IFCFG_STATIC_REDHAT = (
 	('BOOTPROTO', 'none', HARD),	# static?
 	('IPADDR', 'ip_address', MAND),	# ADDRESS?
 	('NETMASK', 'netmask', MAND),
-	('GATEWAY', 'gateway', OPT),
 	('DNSx', '', NAMESERVERS),
 )
 


### PR DESCRIPTION
Update bms-network-setup.py
Ignore empty Interface options.
Configure emtpy options with value 'None' brakes
Network configuration in case of "Oracle Linux".